### PR TITLE
Update the gulpfile to prevent the bundle task from crashing on syntax error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,11 +41,17 @@ gulp.task('live-server', function() {
 
 gulp.task('bundle', function() {
   return browserify({
-      entries: 'app/main.jsx',
-      debug: true,
-    })
+    entries: 'app/main.jsx',
+    debug: true,
+  })
     .transform("babelify", {presets: ["es2015", "react"]})
     .bundle()
+    .on('error', function(err) {
+      console.error(err.message);
+      console.error(err.codeFrame);
+      // end this stream
+      this.emit('end');
+    })
     .pipe(source('app.js'))
     .pipe(buffer())
     // .pipe(uglify())


### PR DESCRIPTION
gulp was crashing every time I had a simple bug in my syntax.  This was annoying.

I used: 
  https://hashnode.com/post/react-tutorial-using-mern-stack-ciiyus9m700qqge53mer0isxz
section 7.4 

as a reference and added error handling to the bundle task.